### PR TITLE
Add interface to get store weight from memory

### DIFF
--- a/glance_store/multi_backend.py
+++ b/glance_store/multi_backend.py
@@ -331,6 +331,34 @@ def verify_store():
         raise RuntimeError(msg)
 
 
+def get_store_weight(store_identifier):
+    """Determine backing store weightage from identifier.
+
+    Given a store identifier, return the appropriate weight of store
+    from memory.
+    """
+    enabled_backends = CONF.enabled_backends
+    enabled_backends.update(_RESERVED_STORES)
+
+    try:
+        scheme = enabled_backends[store_identifier]
+    except KeyError:
+        msg = _("Store for identifier %s not found") % store_identifier
+        raise exceptions.UnknownScheme(msg)
+
+    try:
+        backend_map = location.SCHEME_TO_CLS_BACKEND_MAP[scheme]
+        scheme_info = backend_map[store_identifier]
+    except KeyError:
+        raise exceptions.UnknownScheme(scheme=scheme)
+
+    store = scheme_info['store']
+    if store:
+        return store.weight
+
+    return 0
+
+
 def get_store_from_store_identifier(store_identifier):
     """Determine backing store from identifier.
 


### PR DESCRIPTION
Some of the available glance stores like file, cinder etc has capability to reuse already initiated driver
(DRIVER_REUSABLE = 0b01000000). In Caracal we have added a feature to sort image locations based on store weight. As RBD driver of glance does not have this reuse capability, during image list API call it initializes the RBD driver for each of the available image which is causing noticable delay in list call.

To avoid this, introducing new interface in glance_store which will directly get the weight of the store from memory and return it back to user.

NOTE: Since the current module does not have any test coverage, corresponding tests will be added in glance once we release glance_store with this change.

Related-Bug: #2086675
Change-Id: If6861f3271f50680af271090b516f2add6e392b9 (cherry picked from commit bb4587392a4791d349230b186d50e3045fe2c664)