### PR TITLE
Support multipart upload when image_size == 0

### DIFF
--- a/glance_store/_drivers/s3.py
+++ b/glance_store/_drivers/s3.py
@@ -180,6 +180,7 @@ Related Options:
 """),
     cfg.IntOpt('s3_store_large_object_size',
                default=DEFAULT_LARGE_OBJECT_SIZE,
+               min=0,
                help="""
 What size, in MB, should S3 start chunking image files and do a multipart
 upload in S3.
@@ -190,7 +191,7 @@ upload the image to S3 as is or to split it (Multipart Upload).
 Note: You can only split up to 10,000 images.
 
 Possible values:
-    * Any positive integer value
+    * Any positive integer value or zero
 
 Related Options:
     * s3_store_large_object_chunk_size
@@ -472,6 +473,8 @@ class Store(glance_store.driver.Store):
         result = getattr(store_conf, param)
         if not result:
             if param == 's3_store_create_bucket_on_put':
+                return result
+            if param == 's3_store_large_object_size':
                 return result
             if param == 's3_store_region_name':
                 return result

--- a/releasenotes/notes/s3-store-large-object-size-zero-a24229ae6955b799.yaml
+++ b/releasenotes/notes/s3-store-large-object-size-zero-a24229ae6955b799.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Support setting ``s3_store_large_object_size`` to ``0`` to force multipart
+    upload when ``image_size`` is unknown.
+fixes:
+  - |
+    `Bug #2043740 <https://bugs.launchpad.net/glance-store/+bug/2043740>`_:
+    ``s3_store_large_object_size`` can be set to ``0`` to force multipart
+    upload when creating an image in the S3 backend from a Cinder volume.


### PR DESCRIPTION
When doing an image upload of a volume from cinder-volume to glance with an s3 backend, image_size in this context is zero. As a result the check that image_size is larger than s3_store_large_object_size is always negative and glance_store never uses multipart upload.

As a workaround, allow setting s3_store_large_object_size to 0, which forces glance_store to use multipart upload.

Related-Bug: #2043740
Change-Id: I436d56d0489b081822ed55108e10d43cc38512bb